### PR TITLE
[CORE-4296] Closing ops user cannot see designations added to resware transaction

### DIFF
--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -227,18 +227,21 @@ class PDF::Reader
     # should always be 0, but all sort of crazy junk is prefixed to PDF files
     # in the real world.
     #
-    # Checks up to 50 chars into the file, returns nil if no PDF data detected.
+    # Checks up to 1024 chars into the file,
+    # returns nil if no PDF data detected.
+    # Adobe PDF 1.4 spec (3.4.1) 12. Acrobat viewers require only that the
+    # header appear somewhere within the first 1024 bytes of the file
     #
     def calc_junk_offset(io)
       io.rewind
       offset = io.pos
-      until (c = io.readchar) == '%' || c == 37 || offset > 50
+      until (c = io.readchar) == '%' || c == 37 || offset > 1024
         offset += 1
       end
       io.rewind
-      offset < 50 ? offset : nil
+      offset < 1024 ? offset : nil
     rescue EOFError
-      return nil
+      nil
     end
   end
   ################################################################################


### PR DESCRIPTION
This was happening because we were actually using a file with a lot of junk in the header. However, even though the PDF spec indicates that junk can exist 1024 characters into the file, PDF Reader is only checking for 50. 

Tested using original broken file and offset was correctly given as 421 